### PR TITLE
Update snyk workflow to run on merge to main

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -3,7 +3,7 @@ name: Snyk
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What does this change?

The workflow was previously misconfigured to run on merge to master, which is not the default branch for this repository.

This change will allow snyk monitoring to function as expected on this repository.

## How to test

After merging https://app.snyk.io/org/the-guardian-cuu/project/14767fb6-1856-442a-a47e-5a8a11293db7
 should be up to date with the latest vulnerabilities.