### PR TITLE
Update logback-classic to 1.2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "zuora-invoice-write-offs",
     scalaVersion := "2.13.10",
-    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.7",
+    libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.13",
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     libraryDependencies += "io.kontainers" %% "purecsv" % "1.3.10",
     libraryDependencies += "com.squareup.okhttp3" % "okhttp" % "4.10.0",


### PR DESCRIPTION
## What does this change?

This PR is to upgrade ch.qos.logback:logback-classic to 1.2.13 to resolve 4 high vulnerabilities

<img width="1474" alt="image" src="https://github.com/guardian/zuora-invoice-write-offs/assets/73653255/c0f51aeb-2645-4d2f-8b9f-ff5e6467b1f4">
