### PR TITLE
Update jackson-core to 2.17.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,5 +8,6 @@ lazy val root = (project in file("."))
     libraryDependencies += "com.squareup.okhttp3" % "okhttp" % "4.10.0",
     libraryDependencies += "org.scalaz" % "scalaz-core_2.12" % "7.2.15",
     libraryDependencies += "com.typesafe.play" %% "play-json" % "2.9.4",
-    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2", // Fixes Snyk vulnerability alert
+    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.14.2",
+    dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.17.2",
   )


### PR DESCRIPTION
## What does this change?


Snyk has flagged the current version of jackson-core as a high vulnerability - https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-7569538
This comes via Play:
<img width="1653" alt="image" src="https://github.com/user-attachments/assets/3c990e6e-1cd9-4bbe-827e-9c76b6c09078">


Although there are newer versions of jackson without that vulnerability, the latest version of Play still uses the old version of jackson. (There is https://github.com/playframework/playframework/pull/12440 but things move slowly.)
So for now we have to override the jackson-core version, until Play is updated.