### PR TITLE
Add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **This repo is archived** - the [support-zuora-scripts](https://github.com/guardian/support-zuora-scripts) repo contains a wide variety of scripts and utilities for managing subscriptions, invoices and more.
+
 # Background
 This repo contains scripts which allow you to:
 


### PR DESCRIPTION
## What does this change?
I think this repo can be archived as it has not been maintained or added to in a long time. The [support-zuora-scripts](https://github.com/guardian/support-zuora-scripts) repo is more comprehensive and is more regularly added to.